### PR TITLE
Add results_job.has_token expectation to serialized job output tests

### DIFF
--- a/tests/Functional/Application/GetJobSuccessTest.php
+++ b/tests/Functional/Application/GetJobSuccessTest.php
@@ -113,6 +113,7 @@ class GetJobSuccessTest extends AbstractApplicationTest
                             'request_state' => 'unknown',
                         ],
                         'results_job' => [
+                            'has_token' => false,
                             'request_state' => 'unknown',
                         ],
                         'service_requests' => [],
@@ -142,6 +143,7 @@ class GetJobSuccessTest extends AbstractApplicationTest
                             'request_state' => 'unknown',
                         ],
                         'results_job' => [
+                            'has_token' => false,
                             'request_state' => 'unknown',
                         ],
                         'service_requests' => [
@@ -200,6 +202,7 @@ class GetJobSuccessTest extends AbstractApplicationTest
                             'request_state' => 'unknown',
                         ],
                         'results_job' => [
+                            'has_token' => false,
                             'request_state' => 'unknown',
                         ],
                         'service_requests' => [

--- a/tests/Integration/GetJobSuccessTest.php
+++ b/tests/Integration/GetJobSuccessTest.php
@@ -86,6 +86,7 @@ class GetJobSuccessTest extends AbstractApplicationTest
 
         self::assertSame(
             [
+                'has_token' => false,
                 'request_state' => 'unknown',
             ],
             $responseData['results_job']


### PR DESCRIPTION
Fixes #513