### PR TITLE
RemoteRequestFailure::id is a function of type, code and message

### DIFF
--- a/src/Entity/RemoteRequestFailure.php
+++ b/src/Entity/RemoteRequestFailure.php
@@ -35,15 +35,20 @@ class RemoteRequestFailure
     #[ORM\Column(type: 'string', length: 32, unique: true)]
     private readonly string $id;
 
-    /**
-     * @param non-empty-string $id
-     */
-    public function __construct(string $id, RemoteRequestFailureType $type, int $code, ?string $message)
+    public function __construct(RemoteRequestFailureType $type, int $code, ?string $message)
     {
-        $this->id = $id;
+        $this->id = self::generateId($type, $code, $message);
         $this->type = $type;
         $this->code = $code;
         $this->message = $message;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public static function generateId(RemoteRequestFailureType $type, int $code, ?string $message): string
+    {
+        return md5($type->value . $code . $message);
     }
 
     /**

--- a/tests/Functional/Application/GetJobSuccessTest.php
+++ b/tests/Functional/Application/GetJobSuccessTest.php
@@ -194,7 +194,6 @@ class GetJobSuccessTest extends AbstractApplicationTest
                         (new RemoteRequest($job->id, RemoteRequestType::SERIALIZED_SUITE_GET, 0))
                             ->setState(RequestState::FAILED)
                             ->setFailure(new RemoteRequestFailure(
-                                md5((string) rand()),
                                 RemoteRequestFailureType::NETWORK,
                                 6,
                                 'unable to resolve host "sources.example.com"'
@@ -202,7 +201,6 @@ class GetJobSuccessTest extends AbstractApplicationTest
                         (new RemoteRequest($job->id, RemoteRequestType::SERIALIZED_SUITE_GET, 1))
                             ->setState(RequestState::FAILED)
                             ->setFailure(new RemoteRequestFailure(
-                                md5((string) rand()),
                                 RemoteRequestFailureType::HTTP,
                                 503,
                                 'service unavailable'

--- a/tests/Functional/Repository/RemoteRequestFailureRepositoryTest.php
+++ b/tests/Functional/Repository/RemoteRequestFailureRepositoryTest.php
@@ -79,47 +79,42 @@ class RemoteRequestFailureRepositoryTest extends WebTestCase
      */
     public function removeDataProvider(): array
     {
-        $failureIds = [
-            md5((string) rand()),
-            md5((string) rand()),
-        ];
-
         return [
             'single remote request failure, no remote requests' => [
-                'remoteRequestFailuresCreator' => function () use ($failureIds) {
+                'remoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure($failureIds[0], RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
                     ];
                 },
                 'remoteRequestsCreator' => function () {
                     return [];
                 },
-                'remoteRequestFailureId' => $failureIds[0],
+                'remoteRequestFailureId' => RemoteRequestFailure::generateId(RemoteRequestFailureType::HTTP, 404, null),
                 'expectedRemoteRequestFailuresCreator' => function () {
                     return [];
                 },
             ],
             'multiple remote request failures, no remote requests' => [
-                'remoteRequestFailuresCreator' => function () use ($failureIds) {
+                'remoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure($failureIds[0], RemoteRequestFailureType::HTTP, 404, null),
-                        new RemoteRequestFailure($failureIds[1], RemoteRequestFailureType::HTTP, 503, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 503, null),
                     ];
                 },
                 'remoteRequestsCreator' => function () {
                     return [];
                 },
-                'remoteRequestFailureId' => $failureIds[0],
-                'expectedRemoteRequestFailuresCreator' => function () use ($failureIds) {
+                'remoteRequestFailureId' => RemoteRequestFailure::generateId(RemoteRequestFailureType::HTTP, 404, null),
+                'expectedRemoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure($failureIds[1], RemoteRequestFailureType::HTTP, 503, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 503, null),
                     ];
                 },
             ],
             'single remote request failure in use by single remote request' => [
-                'remoteRequestFailuresCreator' => function () use ($failureIds) {
+                'remoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure($failureIds[0], RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
                     ];
                 },
                 'remoteRequestsCreator' => function (array $remoteRequestFailures) {
@@ -131,10 +126,10 @@ class RemoteRequestFailureRepositoryTest extends WebTestCase
                             ->setFailure($remoteRequestFailure),
                     ];
                 },
-                'remoteRequestFailureId' => $failureIds[0],
-                'expectedRemoteRequestFailuresCreator' => function () use ($failureIds) {
+                'remoteRequestFailureId' => RemoteRequestFailure::generateId(RemoteRequestFailureType::HTTP, 404, null),
+                'expectedRemoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure($failureIds[0], RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
                     ];
                 },
             ],

--- a/tests/Functional/Repository/RemoteRequestRepositoryTest.php
+++ b/tests/Functional/Repository/RemoteRequestRepositoryTest.php
@@ -152,42 +152,36 @@ class RemoteRequestRepositoryTest extends WebTestCase
      */
     public function hasAnyWithFailureDataProvider(): array
     {
-        $failureIds = [
-            md5((string) rand()),
-            md5((string) rand()),
-            md5((string) rand()),
-        ];
-
         return [
             'single remote request failure, no remote requests' => [
-                'remoteRequestFailuresCreator' => function () use ($failureIds) {
+                'remoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure($failureIds[0], RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
                     ];
                 },
                 'remoteRequestsCreator' => function () {
                     return [];
                 },
-                'remoteRequestFailureId' => $failureIds[0],
+                'remoteRequestFailureId' => RemoteRequestFailure::generateId(RemoteRequestFailureType::HTTP, 404, null),
                 'expected' => false,
             ],
             'multiple remote request failures, no remote requests' => [
-                'remoteRequestFailuresCreator' => function () use ($failureIds) {
+                'remoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure($failureIds[0], RemoteRequestFailureType::HTTP, 404, null),
-                        new RemoteRequestFailure($failureIds[1], RemoteRequestFailureType::HTTP, 503, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 503, null),
                     ];
                 },
                 'remoteRequestsCreator' => function () {
                     return [];
                 },
-                'remoteRequestFailureId' => $failureIds[0],
+                'remoteRequestFailureId' => RemoteRequestFailure::generateId(RemoteRequestFailureType::HTTP, 404, null),
                 'expected' => false,
             ],
             'single remote request failure in use by single remote request' => [
-                'remoteRequestFailuresCreator' => function () use ($failureIds) {
+                'remoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure($failureIds[0], RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
                     ];
                 },
                 'remoteRequestsCreator' => function (array $remoteRequestFailures) {
@@ -199,13 +193,13 @@ class RemoteRequestRepositoryTest extends WebTestCase
                             ->setFailure($remoteRequestFailure),
                     ];
                 },
-                'remoteRequestFailureId' => $failureIds[0],
+                'remoteRequestFailureId' => RemoteRequestFailure::generateId(RemoteRequestFailureType::HTTP, 404, null),
                 'expected' => true,
             ],
             'single remote request failure in use by multiple remote requests' => [
-                'remoteRequestFailuresCreator' => function () use ($failureIds) {
+                'remoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure($failureIds[0], RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
                     ];
                 },
                 'remoteRequestsCreator' => function (array $remoteRequestFailures) {
@@ -221,15 +215,13 @@ class RemoteRequestRepositoryTest extends WebTestCase
                             ->setFailure($remoteRequestFailure),
                     ];
                 },
-                'remoteRequestFailureId' => $failureIds[0],
+                'remoteRequestFailureId' => RemoteRequestFailure::generateId(RemoteRequestFailureType::HTTP, 404, null),
                 'expected' => true,
             ],
             'multiple remote request failures, specific remote request failure not in use' => [
-                'remoteRequestFailuresCreator' => function () use ($failureIds) {
+                'remoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure($failureIds[0], RemoteRequestFailureType::HTTP, 404, null),
-                        new RemoteRequestFailure($failureIds[1], RemoteRequestFailureType::HTTP, 404, null),
-                        new RemoteRequestFailure($failureIds[2], RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
                     ];
                 },
                 'remoteRequestsCreator' => function (array $remoteRequestFailures) {
@@ -245,7 +237,7 @@ class RemoteRequestRepositoryTest extends WebTestCase
                             ->setFailure($remoteRequestFailure),
                     ];
                 },
-                'remoteRequestFailureId' => $failureIds[0],
+                'remoteRequestFailureId' => RemoteRequestFailure::generateId(RemoteRequestFailureType::HTTP, 404, null),
                 'expected' => false,
             ],
         ];

--- a/tests/Functional/Services/RemoteRequestRemoverTest.php
+++ b/tests/Functional/Services/RemoteRequestRemoverTest.php
@@ -217,7 +217,7 @@ class RemoteRequestRemoverTest extends WebTestCase
             'single remote request for machine/create, has remote request failure' => [
                 'remoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure(md5((string) rand()), RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
                     ];
                 },
                 'remoteRequestsCreator' => function (string $jobId, array $remoteRequestFailures) {
@@ -289,7 +289,7 @@ class RemoteRequestRemoverTest extends WebTestCase
             'multiple remote requests for machine/create, remote request failure used by single remote request' => [
                 'remoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure(md5((string) rand()), RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
                     ];
                 },
                 'remoteRequestsCreator' => function (string $jobId, array $remoteRequestFailures) {
@@ -324,7 +324,7 @@ class RemoteRequestRemoverTest extends WebTestCase
             'multiple remote requests for machine/create, remote request failure used by multiple remote requests' => [
                 'remoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure('1', RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
                     ];
                 },
                 'remoteRequestsCreator' => function (string $jobId, array $remoteRequestFailures) {
@@ -346,7 +346,7 @@ class RemoteRequestRemoverTest extends WebTestCase
                 'type' => RemoteRequestType::MACHINE_CREATE,
                 'expectedRemoteRequestFailuresCreator' => function () {
                     return [
-                        new RemoteRequestFailure('1', RemoteRequestFailureType::HTTP, 404, null),
+                        new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
                     ];
                 },
                 'expectedRemoteRequestsCreator' => function (string $jobId, array $remoteRequestFailures) {


### PR DESCRIPTION
Fixes #622