### PR TITLE
StartWorkerJobMessage::machineIpAddress is non-empty

### DIFF
--- a/src/Message/StartWorkerJobMessage.php
+++ b/src/Message/StartWorkerJobMessage.php
@@ -11,6 +11,7 @@ class StartWorkerJobMessage extends AbstractRemoteRequestMessage
     /**
      * @param non-empty-string $authenticationToken
      * @param non-empty-string $jobId
+     * @param non-empty-string $machineIpAddress
      */
     public function __construct(
         string $authenticationToken,


### PR DESCRIPTION
Fixes #648