### PR TITLE
RemoteRequest::setFailure() does not accept null

### DIFF
--- a/src/Entity/RemoteRequest.php
+++ b/src/Entity/RemoteRequest.php
@@ -88,7 +88,7 @@ class RemoteRequest implements RemoteRequestInterface, TypedRemoteRequestInterfa
         return $jobId . $type->value . $index;
     }
 
-    public function setFailure(?RemoteRequestFailure $failure): self
+    public function setFailure(RemoteRequestFailure $failure): self
     {
         $this->failure = $failure;
 

--- a/tests/Functional/Repository/RemoteRequestRepositoryTest.php
+++ b/tests/Functional/Repository/RemoteRequestRepositoryTest.php
@@ -223,17 +223,11 @@ class RemoteRequestRepositoryTest extends WebTestCase
                         new RemoteRequestFailure(RemoteRequestFailureType::HTTP, 404, null),
                     ];
                 },
-                'remoteRequestsCreator' => function (array $remoteRequestFailures) {
-                    $remoteRequestFailure = $remoteRequestFailures[1] ?? null;
-                    \assert($remoteRequestFailure instanceof RemoteRequestFailure);
-
+                'remoteRequestsCreator' => function () {
                     return [
-                        (new RemoteRequest(md5((string) rand()), RemoteRequestType::MACHINE_CREATE, 0))
-                            ->setFailure($remoteRequestFailure),
-                        (new RemoteRequest(md5((string) rand()), RemoteRequestType::MACHINE_CREATE, 0))
-                            ->setFailure($remoteRequestFailure),
-                        (new RemoteRequest(md5((string) rand()), RemoteRequestType::MACHINE_CREATE, 0))
-                            ->setFailure($remoteRequestFailure),
+                        new RemoteRequest(md5((string) rand()), RemoteRequestType::MACHINE_CREATE, 0),
+                        new RemoteRequest(md5((string) rand()), RemoteRequestType::MACHINE_CREATE, 0),
+                        new RemoteRequest(md5((string) rand()), RemoteRequestType::MACHINE_CREATE, 0),
                     ];
                 },
                 'remoteRequestFailureId' => RemoteRequestFailure::generateId(RemoteRequestFailureType::HTTP, 404, null),


### PR DESCRIPTION
Fixes #915