### PR TITLE
Set remote request state to 'aborted' for messages that can never be handled

### DIFF
--- a/src/Enum/RequestState.php
+++ b/src/Enum/RequestState.php
@@ -11,4 +11,5 @@ enum RequestState: string
     case FAILED = 'failed';
     case SUCCEEDED = 'succeeded';
     case PENDING = 'pending';
+    case ABORTED = 'aborted';
 }

--- a/src/Event/MessageNotHandleableEvent.php
+++ b/src/Event/MessageNotHandleableEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event;
+
+use App\Message\JobRemoteRequestMessageInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class MessageNotHandleableEvent extends Event
+{
+    public function __construct(
+        public readonly JobRemoteRequestMessageInterface $message,
+    ) {
+    }
+}

--- a/src/MessageFailureHandler/JobNotFoundExceptionHandler.php
+++ b/src/MessageFailureHandler/JobNotFoundExceptionHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MessageFailureHandler;
+
+use App\Event\MessageNotHandleableEvent;
+use App\Exception\MessageHandlerJobNotFoundException;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use SmartAssert\WorkerMessageFailedEventBundle\ExceptionHandlerInterface;
+use Symfony\Component\Messenger\Envelope;
+
+readonly class JobNotFoundExceptionHandler implements ExceptionHandlerInterface
+{
+    public function __construct(
+        private EventDispatcherInterface $eventDispatcher,
+    ) {
+    }
+
+    public function handle(Envelope $envelope, \Throwable $throwable): void
+    {
+        if (!$throwable instanceof MessageHandlerJobNotFoundException) {
+            return;
+        }
+
+        $this->eventDispatcher->dispatch(new MessageNotHandleableEvent($throwable->handledMessage));
+    }
+}

--- a/src/MessageHandler/GetResultsJobStateMessageHandler.php
+++ b/src/MessageHandler/GetResultsJobStateMessageHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\MessageHandler;
 
+use App\Event\MessageNotHandleableEvent;
 use App\Event\ResultsJobStateRetrievedEvent;
 use App\Exception\MessageHandlerJobNotFoundException;
 use App\Exception\MessageHandlerTargetEntityNotFoundException;
@@ -46,6 +47,8 @@ final readonly class GetResultsJobStateMessageHandler
 
         $resultsJob = $this->resultsJobRepository->find($job->id);
         if (null === $resultsJob) {
+            $this->eventDispatcher->dispatch(new MessageNotHandleableEvent($message));
+
             throw new MessageHandlerTargetEntityNotFoundException($message, 'ResultsJob');
         }
 

--- a/src/MessageHandler/GetSerializedSuiteMessageHandler.php
+++ b/src/MessageHandler/GetSerializedSuiteMessageHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\MessageHandler;
 
+use App\Event\MessageNotHandleableEvent;
 use App\Event\SerializedSuiteRetrievedEvent;
 use App\Exception\MessageHandlerJobNotFoundException;
 use App\Exception\MessageHandlerTargetEntityNotFoundException;
@@ -40,6 +41,8 @@ final class GetSerializedSuiteMessageHandler
 
         $serializedSuiteEntity = $this->serializedSuiteRepository->find($job->id);
         if (null === $serializedSuiteEntity) {
+            $this->eventDispatcher->dispatch(new MessageNotHandleableEvent($message));
+
             throw new MessageHandlerTargetEntityNotFoundException($message, 'SerializedSuite');
         }
 

--- a/src/Services/RemoteRequestStateTracker.php
+++ b/src/Services/RemoteRequestStateTracker.php
@@ -7,6 +7,7 @@ namespace App\Services;
 use App\Entity\RemoteRequest;
 use App\Enum\RequestState;
 use App\Event\JobRemoteRequestMessageCreatedEvent;
+use App\Event\MessageNotHandleableEvent;
 use App\Event\MessageNotYetHandleableEvent;
 use App\Message\JobRemoteRequestMessageInterface;
 use App\Repository\RemoteRequestRepository;
@@ -43,6 +44,9 @@ class RemoteRequestStateTracker implements EventSubscriberInterface
             ],
             MessageNotYetHandleableEvent::class => [
                 ['setRemoteRequestStateForMessageNotYetHandleableEvent', 10000],
+            ],
+            MessageNotHandleableEvent::class => [
+                ['setRemoteRequestStateForMessageNotHandleableEvent', 10000],
             ],
         ];
     }
@@ -96,6 +100,16 @@ class RemoteRequestStateTracker implements EventSubscriberInterface
         }
 
         $this->setRemoteRequestForMessage($message, RequestState::HALTED);
+    }
+
+    public function setRemoteRequestStateForMessageNotHandleableEvent(MessageNotHandleableEvent $event): void
+    {
+        $message = $event->message;
+        if (!$message instanceof JobRemoteRequestMessageInterface) {
+            return;
+        }
+
+        $this->setRemoteRequestForMessage($message, RequestState::ABORTED);
     }
 
     private function setRemoteRequestForMessage(

--- a/tests/Integration/MachineCreateMessageHandlingForDeletedJobTest.php
+++ b/tests/Integration/MachineCreateMessageHandlingForDeletedJobTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration;
+
+use App\Entity\Job;
+use App\Entity\RemoteRequest;
+use App\Enum\RemoteRequestAction;
+use App\Enum\RemoteRequestEntity;
+use App\Enum\RequestState;
+use App\Model\RemoteRequestType;
+use App\Repository\JobRepository;
+use App\Repository\RemoteRequestRepository;
+use App\Tests\Application\AbstractApplicationTest;
+use Doctrine\ORM\EntityManagerInterface;
+use SmartAssert\TestAuthenticationProviderBundle\ApiTokenProvider;
+use Symfony\Component\Uid\Ulid;
+
+class MachineCreateMessageHandlingForDeletedJobTest extends AbstractApplicationTest
+{
+    use GetClientAdapterTrait;
+
+    private const int MICROSECONDS_PER_SECOND = 1000000;
+
+    public function testAbortedMachineCreateRequestExists(): void
+    {
+        $apiTokenProvider = self::getContainer()->get(ApiTokenProvider::class);
+        \assert($apiTokenProvider instanceof ApiTokenProvider);
+        $apiToken = $apiTokenProvider->get('user1@example.com');
+
+        $suiteId = (string) new Ulid();
+        \assert('' !== $suiteId);
+
+        $jobRepository = self::getContainer()->get(JobRepository::class);
+        \assert($jobRepository instanceof JobRepository);
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        \assert($entityManager instanceof EntityManagerInterface);
+
+        $remoteRequestRepository = self::getContainer()->get(RemoteRequestRepository::class);
+        \assert($remoteRequestRepository instanceof RemoteRequestRepository);
+
+        foreach ($remoteRequestRepository->findAll() as $remoteRequest) {
+            $entityManager->remove($remoteRequest);
+            $entityManager->flush();
+        }
+
+        $createResponse = self::$staticApplicationClient->makeCreateJobRequest($apiToken, $suiteId, 600);
+
+        self::assertSame(200, $createResponse->getStatusCode());
+        self::assertSame('application/json', $createResponse->getHeaderLine('content-type'));
+
+        $createResponseData = json_decode($createResponse->getBody()->getContents(), true);
+        self::assertIsArray($createResponseData);
+        self::assertArrayHasKey('id', $createResponseData);
+        self::assertTrue(Ulid::isValid($createResponseData['id']));
+        $jobId = $createResponseData['id'];
+
+        $job = $jobRepository->find($jobId);
+        self::assertInstanceOf(Job::class, $job);
+
+        $this->waitUntilMachineCreateRemoteRequestExists($jobId);
+
+        $this->removeJob($jobId);
+
+        $entityManager->clear();
+        $entityManager->flush();
+
+        $this->waitUntilAbortedMachineCreateRemoteRequestExists($jobId);
+
+        $abortedMachineCreateRequestCount = $remoteRequestRepository->count(
+            [
+                'jobId' => $job->id,
+                'state' => RequestState::ABORTED->value,
+                'type' => new RemoteRequestType(
+                    RemoteRequestEntity::MACHINE,
+                    RemoteRequestAction::CREATE,
+                ),
+            ]
+        );
+
+        self::assertSame(
+            1,
+            $abortedMachineCreateRequestCount,
+            'No aborted machine/create request found.'
+        );
+    }
+
+    private function waitUntilMachineCreateRemoteRequestExists(string $jobId): void
+    {
+        $this->waitUntilMachineCreateRemoteRequestsExist($jobId, null);
+    }
+
+    private function waitUntilAbortedMachineCreateRemoteRequestExists(string $jobId): void
+    {
+        $this->waitUntilMachineCreateRemoteRequestsExist($jobId, RequestState::ABORTED->value);
+    }
+
+    private function waitUntilMachineCreateRemoteRequestsExist(string $jobId, ?string $state): void
+    {
+        $waitThreshold = self::MICROSECONDS_PER_SECOND * 30;
+        $totalWaitTime = 0;
+        $period = (int) (self::MICROSECONDS_PER_SECOND * 0.1);
+
+        $remoteRequests = [];
+
+        while (0 === count($remoteRequests) && $totalWaitTime < $waitThreshold) {
+            $totalWaitTime += $period;
+            usleep($period);
+            $remoteRequests = $this->getMachineCreateRemoteRequests($jobId, $state);
+        }
+
+        if ($totalWaitTime >= $waitThreshold) {
+            throw new \RuntimeException('Exceeded threshold waiting for machine create remote requests');
+        }
+    }
+
+    /**
+     * @return RemoteRequest[]
+     */
+    private function getMachineCreateRemoteRequests(
+        string $jobId,
+        ?string $state = null,
+    ): array {
+        $remoteRequestRepository = self::getContainer()->get(RemoteRequestRepository::class);
+        \assert($remoteRequestRepository instanceof RemoteRequestRepository);
+
+        $criteria = [
+            'jobId' => $jobId,
+            'type' => 'machine/create',
+        ];
+
+        if (is_string($state)) {
+            $criteria['state'] = $state;
+        }
+
+        return $remoteRequestRepository->findBy($criteria, ['index' => 'ASC']);
+    }
+
+    private function removeJob(string $jobId): void
+    {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        \assert($entityManager instanceof EntityManagerInterface);
+
+        $queryBuilder = $entityManager->createQueryBuilder();
+        $queryBuilder
+            ->delete(Job::class, 'j')
+            ->where('j.id = :id')
+            ->setParameter('id', $jobId)
+        ;
+
+        $query = $queryBuilder->getQuery();
+        $query->execute();
+    }
+}


### PR DESCRIPTION
Fixes #944