### PR TITLE
RemoteRequestFailure entity cannot guarantee population of non-empty string properties from database

### DIFF
--- a/src/Entity/RemoteRequestFailure.php
+++ b/src/Entity/RemoteRequestFailure.php
@@ -28,9 +28,6 @@ class RemoteRequestFailure implements \JsonSerializable
     #[ORM\Column(type: Types::TEXT, nullable: true)]
     private readonly ?string $message;
 
-    /**
-     * @var non-empty-string
-     */
     #[ORM\Id]
     #[ORM\Column(type: 'string', length: 32, unique: true)]
     private readonly string $id;


### PR DESCRIPTION
Fixes #995