### PR TITLE
RemoteRequest::id does not need to be public

### DIFF
--- a/src/Entity/RemoteRequest.php
+++ b/src/Entity/RemoteRequest.php
@@ -24,7 +24,7 @@ class RemoteRequest implements RemoteRequestInterface, TypedRemoteRequestInterfa
      */
     #[ORM\Id]
     #[ORM\Column(type: 'string', length: 128, unique: true)]
-    public readonly string $id;
+    private readonly string $id;
 
     /**
      * @var non-empty-string


### PR DESCRIPTION
Fixes #1009