### PR TITLE
JobPreparationInspectorInterface, JobComponentHandlerInterface methods can take jobId instead of job

### DIFF
--- a/src/MessageHandler/GetResultsJobStateMessageHandler.php
+++ b/src/MessageHandler/GetResultsJobStateMessageHandler.php
@@ -47,7 +47,7 @@ final readonly class GetResultsJobStateMessageHandler
         }
 
         if (
-            true === $this->jobPreparationInspector->hasFailed($job)
+            true === $this->jobPreparationInspector->hasFailed($job->getId())
             || $resultsJob->hasEndState()
         ) {
             $this->eventDispatcher->dispatch(new MessageNotHandleableEvent($message));

--- a/src/Services/ComponentPreparationFactory.php
+++ b/src/Services/ComponentPreparationFactory.php
@@ -31,7 +31,7 @@ readonly class ComponentPreparationFactory
 
             foreach ($this->jobComponentHandlers as $jobComponentHandler) {
                 if (null === $componentPreparation) {
-                    $componentPreparation = $jobComponentHandler->getComponentPreparation($jobComponent, $job);
+                    $componentPreparation = $jobComponentHandler->getComponentPreparation($jobComponent, $job->getId());
 
                     if ($componentPreparation instanceof ComponentPreparation) {
                         $componentPreparations[$jobComponent->value] = $componentPreparation;

--- a/src/Services/JobComponentHandler/AbstractJobComponentHandler.php
+++ b/src/Services/JobComponentHandler/AbstractJobComponentHandler.php
@@ -9,7 +9,6 @@ use App\Enum\PreparationState;
 use App\Enum\RemoteRequestAction;
 use App\Enum\RequestState;
 use App\Model\ComponentPreparation;
-use App\Model\JobInterface;
 use App\Model\RemoteRequestType;
 use App\Repository\JobComponentRepositoryInterface;
 use App\Repository\RemoteRequestRepository;
@@ -22,31 +21,31 @@ abstract class AbstractJobComponentHandler implements JobComponentHandlerInterfa
     ) {
     }
 
-    public function getComponentPreparation(JobComponent $jobComponent, JobInterface $job): ?ComponentPreparation
+    public function getComponentPreparation(JobComponent $jobComponent, string $jobId): ?ComponentPreparation
     {
         if ($this->getJobComponent() !== $jobComponent) {
             return null;
         }
 
-        if ($this->entityRepository->count(['jobId' => $job->getId()]) > 0) {
+        if ($this->entityRepository->count(['jobId' => $jobId]) > 0) {
             return new ComponentPreparation($jobComponent, PreparationState::SUCCEEDED);
         }
 
-        return $this->deriveFromRemoteRequests($job, $jobComponent);
+        return $this->deriveFromRemoteRequests($jobId, $jobComponent);
     }
 
-    public function getRequestState(JobComponent $jobComponent, JobInterface $job): ?RequestState
+    public function getRequestState(JobComponent $jobComponent, string $jobId): ?RequestState
     {
         if ($this->getJobComponent() !== $jobComponent) {
             return null;
         }
 
-        if ($this->entityRepository->count(['jobId' => $job->getId()]) > 0) {
+        if ($this->entityRepository->count(['jobId' => $jobId]) > 0) {
             return RequestState::SUCCEEDED;
         }
 
         $remoteRequest = $this->remoteRequestRepository->findNewest(
-            $job->getId(),
+            $jobId,
             new RemoteRequestType($jobComponent, RemoteRequestAction::CREATE),
         );
 
@@ -77,10 +76,10 @@ abstract class AbstractJobComponentHandler implements JobComponentHandlerInterfa
 
     abstract protected function getJobComponent(): JobComponent;
 
-    private function deriveFromRemoteRequests(JobInterface $job, JobComponent $jobComponent): ComponentPreparation
+    private function deriveFromRemoteRequests(string $jobId, JobComponent $jobComponent): ComponentPreparation
     {
         $remoteRequest = $this->remoteRequestRepository->findNewest(
-            $job->getId(),
+            $jobId,
             new RemoteRequestType($jobComponent, RemoteRequestAction::CREATE),
         );
 

--- a/src/Services/JobComponentHandler/AbstractJobComponentHandler.php
+++ b/src/Services/JobComponentHandler/AbstractJobComponentHandler.php
@@ -53,14 +53,14 @@ abstract class AbstractJobComponentHandler implements JobComponentHandlerInterfa
         return $remoteRequest?->getState();
     }
 
-    public function hasFailed(JobComponent $jobComponent, JobInterface $job): ?bool
+    public function hasFailed(JobComponent $jobComponent, string $jobId): ?bool
     {
         if ($this->getJobComponent() !== $jobComponent) {
             return null;
         }
 
         $remoteRequest = $this->remoteRequestRepository->findNewest(
-            $job->getId(),
+            $jobId,
             new RemoteRequestType($jobComponent, RemoteRequestAction::CREATE),
         );
 

--- a/src/Services/JobComponentHandler/FallbackHandler.php
+++ b/src/Services/JobComponentHandler/FallbackHandler.php
@@ -8,7 +8,6 @@ use App\Enum\JobComponent;
 use App\Enum\PreparationState;
 use App\Enum\RequestState;
 use App\Model\ComponentPreparation;
-use App\Model\JobInterface;
 
 class FallbackHandler implements JobComponentHandlerInterface
 {
@@ -17,12 +16,12 @@ class FallbackHandler implements JobComponentHandlerInterface
         return -1;
     }
 
-    public function getComponentPreparation(JobComponent $jobComponent, JobInterface $job): ?ComponentPreparation
+    public function getComponentPreparation(JobComponent $jobComponent, string $jobId): ?ComponentPreparation
     {
         return new ComponentPreparation($jobComponent, PreparationState::PENDING);
     }
 
-    public function getRequestState(JobComponent $jobComponent, JobInterface $job): ?RequestState
+    public function getRequestState(JobComponent $jobComponent, string $jobId): ?RequestState
     {
         return RequestState::PENDING;
     }

--- a/src/Services/JobComponentHandler/FallbackHandler.php
+++ b/src/Services/JobComponentHandler/FallbackHandler.php
@@ -27,7 +27,7 @@ class FallbackHandler implements JobComponentHandlerInterface
         return RequestState::PENDING;
     }
 
-    public function hasFailed(JobComponent $jobComponent, JobInterface $job): bool
+    public function hasFailed(JobComponent $jobComponent, string $jobId): bool
     {
         return false;
     }

--- a/src/Services/JobComponentHandler/JobComponentHandlerInterface.php
+++ b/src/Services/JobComponentHandler/JobComponentHandlerInterface.php
@@ -7,13 +7,12 @@ namespace App\Services\JobComponentHandler;
 use App\Enum\JobComponent;
 use App\Enum\RequestState;
 use App\Model\ComponentPreparation;
-use App\Model\JobInterface;
 
 interface JobComponentHandlerInterface
 {
-    public function getComponentPreparation(JobComponent $jobComponent, JobInterface $job): ?ComponentPreparation;
+    public function getComponentPreparation(JobComponent $jobComponent, string $jobId): ?ComponentPreparation;
 
-    public function getRequestState(JobComponent $jobComponent, JobInterface $job): ?RequestState;
+    public function getRequestState(JobComponent $jobComponent, string $jobId): ?RequestState;
 
     public function hasFailed(JobComponent $jobComponent, string $jobId): ?bool;
 }

--- a/src/Services/JobComponentHandler/JobComponentHandlerInterface.php
+++ b/src/Services/JobComponentHandler/JobComponentHandlerInterface.php
@@ -15,5 +15,5 @@ interface JobComponentHandlerInterface
 
     public function getRequestState(JobComponent $jobComponent, JobInterface $job): ?RequestState;
 
-    public function hasFailed(JobComponent $jobComponent, JobInterface $job): ?bool;
+    public function hasFailed(JobComponent $jobComponent, string $jobId): ?bool;
 }

--- a/src/Services/JobPreparationInspector.php
+++ b/src/Services/JobPreparationInspector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enum\JobComponent;
-use App\Model\JobInterface;
 use App\Services\JobComponentHandler\JobComponentHandlerInterface;
 
 readonly class JobPreparationInspector implements JobPreparationInspectorInterface
@@ -18,11 +17,11 @@ readonly class JobPreparationInspector implements JobPreparationInspectorInterfa
     ) {
     }
 
-    public function hasFailed(JobInterface $job): bool
+    public function hasFailed(string $jobId): bool
     {
         foreach (JobComponent::cases() as $jobComponent) {
             foreach ($this->jobComponentHandlers as $jobComponentHandler) {
-                $hasJobComponentFailed = $jobComponentHandler->hasFailed($jobComponent, $job);
+                $hasJobComponentFailed = $jobComponentHandler->hasFailed($jobComponent, $jobId);
 
                 if (true === $hasJobComponentFailed) {
                     return true;

--- a/src/Services/JobPreparationInspectorInterface.php
+++ b/src/Services/JobPreparationInspectorInterface.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Model\JobInterface;
-
 interface JobPreparationInspectorInterface
 {
-    public function hasFailed(JobInterface $job): bool;
+    public function hasFailed(string $jobId): bool;
 }

--- a/src/Services/RequestStatesFactory.php
+++ b/src/Services/RequestStatesFactory.php
@@ -31,7 +31,7 @@ class RequestStatesFactory
 
             foreach ($this->jobComponentHandlers as $jobComponentHandler) {
                 if (null === $requestState) {
-                    $requestState = $jobComponentHandler->getRequestState($jobComponent, $job);
+                    $requestState = $jobComponentHandler->getRequestState($jobComponent, $job->getId());
 
                     if ($requestState instanceof RequestState) {
                         $requestStates[$jobComponent->value] = $requestState;

--- a/tests/Functional/MessageHandler/GetResultsJobStateMessageHandlerTest.php
+++ b/tests/Functional/MessageHandler/GetResultsJobStateMessageHandlerTest.php
@@ -13,7 +13,6 @@ use App\Exception\MessageHandlerTargetEntityNotFoundException;
 use App\Exception\RemoteJobActionException;
 use App\Message\GetResultsJobStateMessage;
 use App\MessageHandler\GetResultsJobStateMessageHandler;
-use App\Model\JobInterface;
 use App\Repository\RemoteRequestRepository;
 use App\Repository\ResultsJobRepository;
 use App\Services\JobPreparationInspectorInterface;
@@ -74,11 +73,7 @@ class GetResultsJobStateMessageHandlerTest extends AbstractMessageHandlerTestCas
         $jobPreparationInspector = \Mockery::mock(JobPreparationInspectorInterface::class);
         $jobPreparationInspector
             ->shouldReceive('hasFailed')
-            ->withArgs(function (JobInterface $passedJob) use ($job) {
-                self::assertSame($job->getId(), $passedJob->getId());
-
-                return true;
-            })
+            ->with($job->getId())
             ->andReturnTrue()
         ;
 
@@ -146,11 +141,7 @@ class GetResultsJobStateMessageHandlerTest extends AbstractMessageHandlerTestCas
         $jobPreparationInspector = \Mockery::mock(JobPreparationInspectorInterface::class);
         $jobPreparationInspector
             ->shouldReceive('hasFailed')
-            ->withArgs(function (JobInterface $passedJob) use ($job) {
-                self::assertSame($job->getId(), $passedJob->getId());
-
-                return true;
-            })
+            ->with($job->getId())
             ->andReturnFalse()
         ;
 


### PR DESCRIPTION
Fixes #1074